### PR TITLE
Missing compiler argument logging-annotation message improvement.

### DIFF
--- a/src/main/java/walkingkooka/j2cl/locale/annotationprocessor/LocaleAwareAnnotationProcessor.java
+++ b/src/main/java/walkingkooka/j2cl/locale/annotationprocessor/LocaleAwareAnnotationProcessor.java
@@ -331,8 +331,14 @@ public abstract class LocaleAwareAnnotationProcessor extends AbstractProcessor {
     }
 
     private Logging reportLoggingAnnotationProcessorArgumentFail(final String message) {
+        return reportLoggingAnnotationProcessorArgumentFail(this.logging, message);
+    }
+
+    static Logging reportLoggingAnnotationProcessorArgumentFail(final String message,
+                                                                final String logging) {
         throw new IllegalStateException(message + " " +
-                CharSequences.quote(LOGGING_ANNOTATION_PROCESSOR_OPTION) + "=" + CharSequences.quoteIfChars(logging) +
+                CharSequences.quote(LOGGING_ANNOTATION_PROCESSOR_OPTION) +
+                (null == logging ? "" : "=" + CharSequences.quoteIfChars(logging)) +
                 ", expected one of " + Arrays.stream(Logging.values()).map(Logging::name).collect(Collectors.joining(", ")) + " (https://github.com/mP1/j2cl-locale#logging-javac-annotation-processor-argument)");
     }
 

--- a/src/test/java/walkingkooka/j2cl/locale/annotationprocessor/LocaleAwareAnnotationProcessorTest.java
+++ b/src/test/java/walkingkooka/j2cl/locale/annotationprocessor/LocaleAwareAnnotationProcessorTest.java
@@ -24,6 +24,7 @@ import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.text.CharSequences;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class LocaleAwareAnnotationProcessorTest implements ClassTesting<LocaleAwareAnnotationProcessor> {
 
@@ -35,6 +36,30 @@ public final class LocaleAwareAnnotationProcessorTest implements ClassTesting<Lo
     @Test
     public void testProtectedDefaultConstructorPresent() throws Exception {
         assertEquals(JavaVisibility.PROTECTED, JavaVisibility.of(LocaleAwareAnnotationProcessor.class.getDeclaredConstructor()));
+    }
+
+    // reportLoggingAnnotationProcessorArgumentFail.....................................................................
+
+    @Test
+    public void testReportLoggingAnnotationProcessorArgumentFailMissingAnnotationProcessor() {
+        this.reportAndFail("ABC",
+                null,
+                "ABC \"walkingkooka.j2cl.locale.Logging\", expected one of NONE, SLASH_SLASH_COMMENTS, TXT_FILE (https://github.com/mP1/j2cl-locale#logging-javac-annotation-processor-argument)");
+    }
+
+    @Test
+    public void testReportLoggingAnnotationProcessorArgumentFail() {
+        this.reportAndFail("ABC",
+                "XYZ",
+                "ABC \"walkingkooka.j2cl.locale.Logging\"=\"XYZ\", expected one of NONE, SLASH_SLASH_COMMENTS, TXT_FILE (https://github.com/mP1/j2cl-locale#logging-javac-annotation-processor-argument)");
+    }
+
+    private void reportAndFail(final String message,
+                               final String logging,
+                               final String expected) {
+        final IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> LocaleAwareAnnotationProcessor.reportLoggingAnnotationProcessorArgumentFail(message, logging));
+        assertEquals(expected, thrown.getMessage(), "message");
     }
 
     // stringDeclaration................................................................................................


### PR DESCRIPTION
- Message no longer includes "=null"