### PR TITLE
generate class until Environment.processingOver removed

### DIFF
--- a/src/main/java/walkingkooka/j2cl/locale/annotationprocessor/LocaleAwareAnnotationProcessor.java
+++ b/src/main/java/walkingkooka/j2cl/locale/annotationprocessor/LocaleAwareAnnotationProcessor.java
@@ -97,10 +97,7 @@ public abstract class LocaleAwareAnnotationProcessor extends AbstractProcessor {
 
         // assume null means generated source does not exist...
         if (null == exists) {
-            // without this check the generated class will be written multiple times resulting in an exception when attempting to create the file.
-            if (environment.processingOver()) {
-                this.process0();
-            }
+            this.process0();
         }
 
         return false; // whether or not the set of annotation types are claimed by this processor


### PR DESCRIPTION
- Removed delayed *.java generation because eventually caused the message below which meant generated *.java was not compiled.
- Warning: File for type '[Insert class here]' created in the last round will not be subject to annotation processing